### PR TITLE
再び、除外ファイル更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,5 @@ sysinfo.txt
 *.unitypackage
 Resources/
 
-StreamingAssets/BGM/
+Piarhythm/Assets/StreamingAssets/BGM
+Piarhythm/Assets/StreamingAssets/BGM.meta


### PR DESCRIPTION
BGMが消えたので、一度戻してからもう一度変更した。
その際、除外ファイルの設定がうまくいっていなかったから、変更した。
これでOK。