### PR TITLE
BGMの開始時間と終了時間の実装

### DIFF
--- a/Piarhythm/Assets/Scripts/Edit/BGMSheetController.cs
+++ b/Piarhythm/Assets/Scripts/Edit/BGMSheetController.cs
@@ -104,10 +104,9 @@ public class BGMSheetController : MonoBehaviour
 					m_menuController.UpdateDisplayWholeTimeText(m_BGMData.endTime);
 					m_optionSheetController.SetWholeTime(m_BGMData.endTime);
 
-					// データの取得
-					float[] allSamples = new float[m_audioClip.samples * m_audioClip.channels];
-					m_audioClip.GetData(allSamples, 0);
-					m_notesEditScrollbarController.UpdateTexture(allSamples);
+					// オーディオクリップを設定し、スクロールバーのテクスチャを更新する
+					m_notesEditScrollbarController.SetAudioClip(m_audioClip);
+					m_notesEditScrollbarController.UpdateTexture(m_BGMData, m_BGMData.endTime);
 
 					// AudioSourceに設定する
 					m_editManager.SetAudioClip(m_audioClip);
@@ -162,6 +161,9 @@ public class BGMSheetController : MonoBehaviour
 
 		// データを更新する
 		m_BGMData.startTime = startTime;
+
+		// スクロールバーのテクスチャの更新
+		m_notesEditScrollbarController.UpdateTexture(m_BGMData, m_optionSheetController.GetWholeTime());
 	}
 	#endregion
 
@@ -184,6 +186,9 @@ public class BGMSheetController : MonoBehaviour
 
 		// データを更新する
 		m_BGMData.endTime = endTime;
+
+		// スクロールバーのテクスチャの更新
+		m_notesEditScrollbarController.UpdateTexture(m_BGMData, m_optionSheetController.GetWholeTime());
 	}
 	#endregion
 

--- a/Piarhythm/Assets/Scripts/Edit/EditManager.cs
+++ b/Piarhythm/Assets/Scripts/Edit/EditManager.cs
@@ -82,11 +82,12 @@ public class EditManager : MonoBehaviour
 			// 全てのノーツの更新処理をする
 			m_notesManager.UpdateAllEditNotes(m_elapsedTime);
 
+			// BGMを止める
+			PiarhythmDatas.BGMData bgmData = m_bgmSheetController.GetBGMData();
+			if (m_audioSource.time >= bgmData.endTime) m_audioSource.Stop();
+
 			// 楽曲が終了した
-			if (m_elapsedTime >= m_optionSheetController.GetWholeTime())
-			{
-				FinishedMusic();
-			}
+			if (m_elapsedTime >= m_optionSheetController.GetWholeTime()) FinishedMusic();
 		}
 	}
 	#endregion
@@ -110,8 +111,11 @@ public class EditManager : MonoBehaviour
 		// 現在時間の取得
 		m_elapsedTime = m_musicalScoreController.GetNowTime();
 
+		// BGMデータの取得
+		PiarhythmDatas.BGMData bgmData = m_bgmSheetController.GetBGMData();
+
 		// 再生位置を調節する
-		m_audioSource.time = m_elapsedTime;
+		m_audioSource.time = m_elapsedTime + bgmData.startTime;
 
 		// BGMを再生させる
 		if (m_audioSource.clip) m_audioSource.Play();

--- a/Piarhythm/Assets/Scripts/Edit/MenuController.cs
+++ b/Piarhythm/Assets/Scripts/Edit/MenuController.cs
@@ -50,7 +50,7 @@ public class MenuController : MonoBehaviour
 	public void UpdateDisplayWholeTimeText(float wholeTime)
 	{
 		// 表示する文字列の作成
-		string displayStr = "\t";
+		string displayStr = "/\t";
 		displayStr += wholeTime.ToString();
 
 		// UIの更新

--- a/Piarhythm/Assets/Scripts/Edit/OptionSheetController.cs
+++ b/Piarhythm/Assets/Scripts/Edit/OptionSheetController.cs
@@ -30,6 +30,10 @@ public class OptionSheetController : MonoBehaviour
 	private MusicalScoreController m_musicalScoreController = null;
 	[SerializeField]
 	private MenuController m_menuController = null;
+	[SerializeField]
+	private BGMSheetController m_bgmSheetController = null;
+	[SerializeField]
+	private NotesEditScrollbarController m_notesEditScrollbarController = null;
 
 
 	// メンバ関数の定義 =====================================================
@@ -50,6 +54,9 @@ public class OptionSheetController : MonoBehaviour
 		m_wholeTime = float.Parse(m_wholeTimeInputField.text);
 		m_musicalScoreController.ChangeScoreLength(m_wholeTime);
 		m_menuController.UpdateDisplayWholeTimeText(m_wholeTime);
+
+		// スクロールバーのテクスチャを更新する
+		m_notesEditScrollbarController.UpdateTexture(m_bgmSheetController.GetBGMData(), m_wholeTime);
 	}
 	#endregion
 


### PR DESCRIPTION
# 変更点
BGMの開始時間と終了時間の入力された値の反映
再生時の開始時間を入力値に設定し、終了時間を迎えたらBGMだけ停止する。
スクロールバーのテクスチャをBGMの時間分だけ描画するように実装を変更

# 工夫点
テクスチャの描画範囲を曲全体の割合分だけ描画するようにした。
例：全体時間：300
　　BGMの開始時間：100
　　BGMの終了時間：200
　　のとき、スクロールバーの下から1/3を描画して、残りの2/3を空白にする。